### PR TITLE
Fix governance voting-power validation and contribution vector growth bug

### DIFF
--- a/programs/halo-protocol/src/errors.rs
+++ b/programs/halo-protocol/src/errors.rs
@@ -137,4 +137,6 @@ pub enum HaloError {
     NoClaimableYield,
     #[msg("Unauthorized member")]
     UnauthorizedMember,
+    #[msg("Invalid token account")]
+    InvalidTokenAccount,
 }

--- a/programs/halo-protocol/src/instructions.rs
+++ b/programs/halo-protocol/src/instructions.rs
@@ -210,8 +210,8 @@ pub(crate) fn contribute(ctx: Context<Contribute>, amount: u64) -> Result<()> {
             .ok_or(HaloError::ArithmeticOverflow)?;
     } else {
         // Ensure we have enough space in the vector
-        let current_len = circle.monthly_contributions.len();
-        while current_len <= current_month as usize {
+        while circle.monthly_contributions.len() <= current_month as usize {
+            let current_len = circle.monthly_contributions.len();
             circle.monthly_contributions.push(MonthlyContribution {
                 month: current_len as u8,
                 contributions: Vec::new(),
@@ -1266,19 +1266,19 @@ pub(crate) fn create_proposal(
 pub(crate) fn cast_vote(
     ctx: Context<CastVote>,
     support: bool,
-    voting_power: u64,
 ) -> Result<()> {
     let proposal = &mut ctx.accounts.proposal;
     let voter = &ctx.accounts.voter;
     let vote_account = &mut ctx.accounts.vote;
     let clock = Clock::get()?;
+    let voting_power = ctx.accounts.voter_token_account.amount;
 
     // Check proposal is active and in voting period
     require!(proposal.is_active(), HaloError::ProposalNotActive);
     require!(clock.unix_timestamp >= proposal.voting_start, HaloError::VotingPeriodNotStarted);
     require!(!proposal.voting_ended(clock.unix_timestamp), HaloError::VotingPeriodEnded);
 
-    // Validate voting power (this should be validated against SPL token balance)
+    // Validate voting power from the provided SPL token balance
     require!(voting_power > 0, HaloError::InsufficientVotingPower);
     
     // Calculate quadratic weight: sqrt(voting_power)
@@ -1546,7 +1546,10 @@ pub struct CastVote<'info> {
     #[account(mut)]
     pub voter: Signer<'info>,
 
-    // SPL Token account for voting power validation
+    // SPL token account used to derive voting power.
+    #[account(
+        constraint = voter_token_account.owner == voter.key() @ HaloError::InvalidTokenAccount
+    )]
     pub voter_token_account: Account<'info, TokenAccount>,
 
     pub system_program: Program<'info, System>,

--- a/programs/halo-protocol/src/lib.rs
+++ b/programs/halo-protocol/src/lib.rs
@@ -103,9 +103,8 @@ pub mod halo_protocol {
     pub fn cast_vote(
         ctx: Context<CastVote>,
         support: bool,
-        voting_power: u64,
     ) -> Result<()> {
-        instructions::cast_vote(ctx, support, voting_power)
+        instructions::cast_vote(ctx, support)
     }
 
     pub fn execute_proposal(ctx: Context<ExecuteProposal>) -> Result<()> {


### PR DESCRIPTION
### Motivation
- Prevent callers from spoofing governance voting power by removing a caller-supplied `voting_power` argument and deriving vote weight from an on-chain SPL token account.
- Fix a correctness bug where `monthly_contributions` could fail to expand because a stale `current_len` value was used in the growth loop.
- Add a defensive ownership check on the voter token account to ensure vote weight is taken from an account owned by the signer.

### Description
- Changed `cast_vote` to derive `voting_power` from `voter_token_account.amount` and removed the external `voting_power` parameter from the program entrypoint in `lib.rs` so callers cannot supply arbitrary weights.
- Added an account constraint `voter_token_account.owner == voter.key()` with a new `InvalidTokenAccount` error in `errors.rs` to validate token-account ownership.
- Fixed the contribution vector expansion in `instructions.rs` by re-evaluating `circle.monthly_contributions.len()` inside the `while` loop so new `MonthlyContribution` entries are added until the required index exists.
- Updated related instruction structs and internal tallying logic to use the derived `voting_power` and preserved existing quadratic-weight calculations and proposal tally updates.

### Testing
- Ran `cargo test --workspace`, which completed successfully (unit tests passed and program built). 
- Ran `npm audit --audit-level=moderate`, which was blocked by the environment registry with HTTP 403 (audit endpoint inaccessible). 
- Attempted `cargo audit`/`cargo install cargo-audit`, but installation and registry access were blocked by network 403 responses in this environment, so a full Rust dependency vulnerability scan could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58face84083319a66c337c4ee6177)